### PR TITLE
Fixed two bugs

### DIFF
--- a/completion-rake
+++ b/completion-rake
@@ -11,7 +11,7 @@
 __rake() {
   local rake_cmd="$1"
   # $2 returns just the part after the last colon
-  local cur=${COMP_WORDS[$COMP_CWORD]}
+  local cur="$(echo "${COMP_WORDS[@]}" | sed 's/ : /:/g; s/ :$/:/; s/^.* //')"
   local prev=$3
   COMPREPLY=()
 


### PR DESCRIPTION
Hey mate,

Thing the first pull request failed... Anyways, two patches for you:

1) Rake completion now includes tasks without descriptions.
So now test:functionals and test:units (under rails projects) will be visible to bash completion. (Previously they weren't.)

2)     Fixed bug where rake completion wouldn't work with colons (at least on Ubuntu 10.10)
So the following now work:
      rake tes<tab>
      rake test:<tab>
      rake test:f<tab>
