### PR TITLE
Update gem and ruby executable version suffixes

### DIFF
--- a/completion-gem
+++ b/completion-gem
@@ -118,5 +118,5 @@ __gem_command_options() {
             end' 2>/dev/null
 }
 
-complete -F __gem -o bashdefault -o default gem gem1.8 gem1.9 jgem
+complete -F __gem -o bashdefault -o default gem gem1.{8..9} gem2.{0..7} jgem
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-ruby
+++ b/completion-ruby
@@ -70,5 +70,5 @@ __ruby() {
     fi
 }
 
-complete -F __ruby -o filenames -o bashdefault -o default ruby ruby1.8 ruby1.9
+complete -F __ruby -o filenames -o bashdefault -o default ruby ruby1.{8..9} ruby2.{0..7}
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -95,7 +95,7 @@ else
         }
     fi
 
-    _cr_load gem gem1.8 gem1.9 jgem
+    _cr_load gem gem1.{8..9} gem2.{0..7} jgem
     _cr_load jruby
     _cr_load rails
     _cr_load bundle

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -100,7 +100,7 @@ else
     _cr_load rails
     _cr_load bundle
     _cr_load rake
-    _cr_load ruby ruby1.8 ruby1.9
+    _cr_load ruby ruby1.{8..9} ruby2.{0..7}
 
     unset -f _cr_load _cr_anycmd
     unset -v _CR_PATH


### PR DESCRIPTION
Both `gem` and `ruby` are installed with a version suffix (e.g. `ruby2.7`).  The current code matches 1.8 and 1.9, update it to match 1.8 through 2.7.

Thanks for considering,
Kevin

P.S.  I did not update `rake` since I wasn't aware of a system where it is installed with Ruby version suffixes.  The suffixes are also not used in `completion-ruby-all`.  Should `rake1.8` and `rake1.9` be removed?