### PR TITLE
bundle: complete `bundler` command as well

### DIFF
--- a/completion-bundle
+++ b/completion-bundle
@@ -250,5 +250,5 @@ __bundle_exec_ruby() {
 }
 
 
-complete -F __bundle -o bashdefault -o default bundle
+complete -F __bundle -o bashdefault -o default bundle bundler
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -98,7 +98,7 @@ else
     _cr_load gem gem1.8 gem1.9 jgem
     _cr_load jruby
     _cr_load rails
-    _cr_load bundle
+    _cr_load bundle bundler
     _cr_load rake
     _cr_load ruby ruby1.8 ruby1.9
 


### PR DESCRIPTION
On Debian, the `ruby-bundler` package ships the bundler commmand as both `/usr/bin/bundle` and `/usr/bin/bundler`.  It would be nice if the completion worked for either alias.

Thanks for considering,
Kevin