### PR TITLE
Update executable version suffixes for ruby 3.0-3.3

### DIFF
--- a/completion-bundle
+++ b/completion-bundle
@@ -250,5 +250,5 @@ __bundle_exec_ruby() {
 }
 
 
-complete -F __bundle -o bashdefault -o default bundle bundler
+complete -F __bundle -o bashdefault -o default bundle bundle2.{0..7} bundle3.{0..3} bundler bundler2.{0..7} bundler3.{0..3}
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-gem
+++ b/completion-gem
@@ -137,5 +137,5 @@ __gem_command_options() {
             end' 2>/dev/null
 }
 
-complete -F __gem -o bashdefault -o default gem gem1.{8..9} gem2.{0..7} jgem
+complete -F __gem -o bashdefault -o default gem gem1.{8..9} gem2.{0..7} gem3.{0..3} jgem
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-rake
+++ b/completion-rake
@@ -180,5 +180,5 @@ __rake_tasks() {
     fi
 }
 
-complete -F __rake -o bashdefault -o default rake rake1.8 rake1.9
+complete -F __rake -o bashdefault -o default rake rake1.{8..9} rake2.{0..7} rake3.{0..3}
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-ruby
+++ b/completion-ruby
@@ -73,5 +73,5 @@ __ruby() {
     fi
 }
 
-complete -F __ruby -o filenames -o bashdefault -o default ruby ruby1.{8..9} ruby2.{0..7}
+complete -F __ruby -o filenames -o bashdefault -o default ruby ruby1.{8..9} ruby2.{0..7} ruby3.{0..3}
 # vim: ai ft=sh sw=4 sts=4 et

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -96,7 +96,7 @@ else
         }
     fi
 
-    _cr_load gem gem1.{8..9} gem2.{0..7} jgem
+    _cr_load gem gem1.{8..9} gem2.{0..7} gem3.{0..3} jgem
     _cr_load jruby
     _cr_load rails
     _cr_load bundle bundler

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -99,7 +99,7 @@ else
     _cr_load gem gem1.{8..9} gem2.{0..7} gem3.{0..3} jgem
     _cr_load jruby
     _cr_load rails
-    _cr_load bundle bundler
+    _cr_load bundle bundle2.{0..7} bundle3.{0..3} bundler bundler2.{0..7} bundler3.{0..3}
     _cr_load rake
     _cr_load ruby ruby1.{8..9} ruby2.{0..7} ruby3.{0..3}
 

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -101,7 +101,7 @@ else
     _cr_load rails
     _cr_load bundle bundler
     _cr_load rake
-    _cr_load ruby ruby1.{8..9} ruby2.{0..7}
+    _cr_load ruby ruby1.{8..9} ruby2.{0..7} ruby3.{0..3}
 
     unset -f _cr_load _cr_anycmd
     unset -v _CR_PATH

--- a/completion-ruby-all
+++ b/completion-ruby-all
@@ -100,7 +100,7 @@ else
     _cr_load jruby
     _cr_load rails
     _cr_load bundle bundle2.{0..7} bundle3.{0..3} bundler bundler2.{0..7} bundler3.{0..3}
-    _cr_load rake
+    _cr_load rake rake1.{8..9} rake2.{0..7} rake3.{0..3}
     _cr_load ruby ruby1.{8..9} ruby2.{0..7} ruby3.{0..3}
 
     unset -f _cr_load _cr_anycmd


### PR DESCRIPTION
Completions are currently only installed for commands with version suffixes between 1.8 and 2.7.  This PR adds completion for `gem` and `ruby` with version suffixes 3.0, 3.1, 3.2, and 3.3.  It also adds completion for `bundle` and `rake` commands with version suffixes, which were not previously supported (or incompletely supported).  If you'd prefer a separate PR for these additions, please let me know.

Thanks for considering,
Kevin

Previous update: #11