### PR TITLE
Rails 3.2 support

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -53,7 +53,7 @@ test-bundle:
 
 test-bundle-all:
     BUILD +test-bundle --RUBY_VERSION=3.0 --RAILS_VERSION="~>6.0"
-    BUILD +test-bundle --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.0"
+    BUILD +test-bundle --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.1.0"
     BUILD +test-bundle --RUBY_VERSION=3.1 --RAILS_VERSION="~>7.0"
     BUILD +test-bundle --RUBY_VERSION=3.2 --RAILS_VERSION="~>7.0"
     BUILD +test-bundle --RUBY_VERSION=3.3 --RAILS_VERSION="~>7.0"
@@ -109,7 +109,7 @@ test-rails:
 
 test-rails-all:
     BUILD +test-rails --RUBY_VERSION=3.0 --RAILS_VERSION="~>6.0"
-    BUILD +test-rails --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.0"
+    BUILD +test-rails --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.1.0"
     BUILD +test-rails --RUBY_VERSION=3.1 --RAILS_VERSION="~>7.0"
     BUILD +test-rails --RUBY_VERSION=3.2 --RAILS_VERSION="~>7.0"
     BUILD +test-rails --RUBY_VERSION=3.3 --RAILS_VERSION="~>7.0"
@@ -124,7 +124,7 @@ test-rake:
 
 test-rake-all:
     BUILD +test-rake --RUBY_VERSION=3.0 --RAILS_VERSION="~>6.0"
-    BUILD +test-rake --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.0"
+    BUILD +test-rake --RUBY_VERSION=3.0 --RAILS_VERSION="~>7.1.0"
     BUILD +test-rake --RUBY_VERSION=3.1 --RAILS_VERSION="~>7.0"
     BUILD +test-rake --RUBY_VERSION=3.2 --RAILS_VERSION="~>7.0"
     BUILD +test-rake --RUBY_VERSION=3.3 --RAILS_VERSION="~>7.0"

--- a/Earthfile
+++ b/Earthfile
@@ -17,6 +17,7 @@ rails-app:
     FROM +ruby
 
     ARG RAILS_VERSION="~>7.0"
+    RUN gem update --system
     RUN gem install rails --version "$RAILS_VERSION"
 
     WORKDIR /usr/src

--- a/tests/test-utils
+++ b/tests/test-utils
@@ -1,6 +1,9 @@
 #! bash
 [[ -n $BASH_COMPLETION_SCRIPT ]] && source "$BASH_COMPLETION_SCRIPT"
 
+# This builtin only works in real completions, so stub it for the tests
+compopt() { true; }
+
 begin-test() {
     echo "TEST: $1"
 }


### PR DESCRIPTION
No changes seem needed, other than disabling the Ruby 3.0 + Rails ≥7.2 combo, and working around a bug on outdated Rubygems environments.